### PR TITLE
Add BoringSSL flavor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ install:
 - ln -s $TRAVIS_BUILD_DIR $(brew --repo)/Library/Taps/ilammy/homebrew-themis
 
 script:
+# BoringSSL flavor
+- brew install themis --verbose
+- brew audit themis --strict
+- brew test themis
+- brew remove themis
 # OpenSSL flavor
 - brew install themis-openssl --verbose
 - brew audit themis-openssl --strict

--- a/Formula/themis-libressl.rb
+++ b/Formula/themis-libressl.rb
@@ -5,7 +5,8 @@ class ThemisLibressl < Formula
   sha256 "329a981e7e57a90107b330172b738104f7189cb20eac043d708c23c5db1570fb"
 
   depends_on "libressl"
-  conflicts_with "themis-openssl", :because => "only one flavor of Themis can exist in PATH"
+  conflicts_with "themis", "themis-openssl",
+    :because => "only one flavor of Themis can exist in PATH"
 
   def install
     ENV["ENGINE"] = "libressl"

--- a/Formula/themis-openssl.rb
+++ b/Formula/themis-openssl.rb
@@ -5,7 +5,8 @@ class ThemisOpenssl < Formula
   sha256 "329a981e7e57a90107b330172b738104f7189cb20eac043d708c23c5db1570fb"
 
   depends_on "openssl"
-  conflicts_with "themis-libressl", :because => "only one flavor of Themis can exist in PATH"
+  conflicts_with "themis", "themis-libressl",
+    :because => "only one flavor of Themis can exist in PATH"
 
   def install
     ENV["ENGINE"] = "openssl"

--- a/Formula/themis.rb
+++ b/Formula/themis.rb
@@ -1,0 +1,60 @@
+class Themis < Formula
+  desc "High-level cryptographic primitives (BoringSSL flavor)"
+  homepage "https://www.cossacklabs.com/themis"
+  url "https://github.com/cossacklabs/themis/archive/0.10.0.tar.gz"
+  sha256 "329a981e7e57a90107b330172b738104f7189cb20eac043d708c23c5db1570fb"
+
+  depends_on "cmake" => [:build]
+  depends_on "go"    => [:build]
+  conflicts_with "themis-libressl", "themis-openssl",
+    :because => "only one flavor of Themis can exist in PATH"
+
+  # BoringSSL is not available on Homebrew and never will be because its
+  # distribution and versioning model strongly suggests projects to build
+  # whatever version they like and link against that statically because
+  # there are no guarantees of API or ABI stability. <okay.jpg>
+  resource "BoringSSL" do
+    url "https://github.com/google/boringssl.git",
+      :using => :git,
+      :revision => "cc9d935256539af2d3b7f831abf57c0d685ffd81"
+  end
+
+  def install
+    @boringssl = "#{Dir.pwd}/boringssl"
+    Dir.mkdir "#{@boringssl}/"
+    Dir.mkdir "#{@boringssl}/include"
+    Dir.mkdir "#{@boringssl}/lib"
+    resource("BoringSSL").stage do
+      Dir.mkdir "build"
+      Dir.chdir "build" do
+        system "cmake", "-DCMAKE_BUILD_TYPE=RelWithDebInfo", ".."
+        system "cmake", "--build", "."
+        # Thank you Google for providing a convenient install target! /s
+        cp_r "../include/openssl",   "#{@boringssl}/include"
+        cp "crypto/libcrypto.a",     "#{@boringssl}/lib"
+        cp "decrepit/libdecrepit.a", "#{@boringssl}/lib"
+        cp "ssl/libssl.a",           "#{@boringssl}/lib"
+      end
+    end
+    ENV["ENGINE"] = "boringssl"
+    ENV["ENGINE_INCLUDE_PATH"] = "#{@boringssl}/include"
+    ENV["ENGINE_LIB_PATH"] = "#{@boringssl}/lib"
+    ENV["PREFIX"] = prefix
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOF
+      #include <themis/themis.h>
+      int main(void)
+      {
+        printf("%s", themis_version());
+        return 0;
+      }
+    EOF
+    system ENV.cc, "test.c", "-o", "check-themis-version", "-lthemis"
+    version = shell_output("./check-themis-version")
+    # The 0.10 release is slightly buggy and identifies itself as 0.9
+    assert_match(/\bthemis 0.9\b/, version)
+  end
+end

--- a/README.md
+++ b/README.md
@@ -18,31 +18,34 @@ brew tap ilammy/homebrew-themis
 Then you may install the latest stable release:
 
 ```console
-brew install themis-openssl
+brew install themis
 ```
 
 In order to upgrade run this:
 
 ```console
 brew update
-brew upgrade themis-openssl
+brew upgrade themis
 ```
 
 ## Selecting Crypto Backend
 
-Currently Themis leverages existing cryptographic libraries for its operation.
-Themis supports OpenSSL, LibreSSL, and BoringSSL as engine backends.
-Homebrew core currently provides only OpenSSL and LibreSSL.
-You need to select the backend by installing an appropriate Themis flavor:
+Themis leverages existing cryptographic libraries for its operation.
+Currently BoringSSL, LibreSSL, OpenSSL are supported as engine backends.
+You may select the backend by installing an appropriate Themis flavor:
 
+- `themis` (BoringSSL is the default)
 - `themis-openssl`
 - `themis-libressl`
 
-The appropriate backend library will be pulled and installed automatically.
+By default, Themis uses its own private version of BoringSSL.
+OpenSSL and LibreSSL flavors use libraries provided by Homebrew,
+they will be pulled and installed automatically if necessary.
 
-Please note that you cannot have both flavors simultaneously _linked_
+Please note that you cannot have multiple flavors simultaneously _linked_
 (installed into the default search path).
-You can have both available, but first you must `brew unlink` one of them.
+You can have them installed and available for applications,
+but you must `brew unlink` them to avoid conflicts.
 
 ## Usage
 
@@ -54,7 +57,7 @@ You can check the installation like this
 by asking Homebrew to compile a simple C program linking it against Themis:
 
 ```console
-brew test themis-openssl
+brew test themis
 ```
 
 ## Licensing


### PR DESCRIPTION
Themis is going to use BoringSSL as its main backend some day so let's make it available via Homebrew. And make it the default flavor in order to facilitate testing, ninja-style.

The formula is not pretty but the users are not supposed to examine it too closely.

Resolves #1 